### PR TITLE
yellow color on the hv button

### DIFF
--- a/Gui/forms/form_tubewidget.ui
+++ b/Gui/forms/form_tubewidget.ui
@@ -432,7 +432,8 @@
              </property>
              <property name="icon">
               <iconset resource="../include/icons.qrc">
-               <normaloff>:/icons/images/highvoltage.png</normaloff>:/icons/images/highvoltage.png</iconset>
+               <normaloff>:/icons/images/highvoltageoff.png</normaloff>
+               <normalon>:/icons/images/highvoltage.png</normalon>:/icons/images/highvoltageoff.png</iconset>
              </property>
              <property name="iconSize">
               <size>
@@ -929,11 +930,29 @@
                 </color>
                </brush>
               </colorrole>
+              <colorrole role="PlaceholderText">
+               <brush brushstyle="NoBrush">
+                <color alpha="128">
+                 <red>255</red>
+                 <green>0</green>
+                 <blue>0</blue>
+                </color>
+               </brush>
+              </colorrole>
              </active>
              <inactive>
               <colorrole role="Text">
                <brush brushstyle="SolidPattern">
                 <color alpha="255">
+                 <red>255</red>
+                 <green>0</green>
+                 <blue>0</blue>
+                </color>
+               </brush>
+              </colorrole>
+              <colorrole role="PlaceholderText">
+               <brush brushstyle="NoBrush">
+                <color alpha="128">
                  <red>255</red>
                  <green>0</green>
                  <blue>0</blue>
@@ -948,6 +967,15 @@
                  <red>139</red>
                  <green>142</green>
                  <blue>142</blue>
+                </color>
+               </brush>
+              </colorrole>
+              <colorrole role="PlaceholderText">
+               <brush brushstyle="NoBrush">
+                <color alpha="128">
+                 <red>255</red>
+                 <green>0</green>
+                 <blue>0</blue>
                 </color>
                </brush>
               </colorrole>

--- a/Gui/src/TubeWidget.cpp
+++ b/Gui/src/TubeWidget.cpp
@@ -137,6 +137,12 @@ void TubeWidget::GetHighVoltage() {
     connect(pushHighVoltage, SIGNAL(toggled(bool)), this,
             SLOT(SetHighVoltage(bool)));
     bool hv = pushHighVoltage->isChecked();
+    QIcon iconOn(":/icons/images/highvoltage.png");
+    QIcon iconOff(":/icons/images/highvoltageoff.png");
+    if (hv)
+        pushHighVoltage->setIcon(iconOn);
+    else
+        pushHighVoltage->setIcon(iconOff);
     frameShutters->setEnabled(hv);
     CheckWarning();
 }


### PR DESCRIPTION
rhl8 for some reason does not accept the different states for an icon on the designer, so have to put explicitly the yellow and grey icons for the different push button states (only rhel8 issue, not for rhel7 or fedora)